### PR TITLE
Add YAML sequence playback feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,27 @@ Neuropuppet supports:
 
 ---
 
+## 🕺 Scripted Sequences
+
+Define motor actions in a YAML file and play them back with `--sequence`.
+
+```yaml
+- motor: 1
+  steps: 200
+  delay: 0.5
+- motor: 2
+  steps: -200
+  delay: 0.5
+```
+
+Run the file:
+
+```bash
+python main.py --sequence demo_sequence.yaml
+```
+
+---
+
 ## 🧪 Testing & Calibration
 
 - Manual homing or switch-based homing

--- a/core/sequence.py
+++ b/core/sequence.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+import yaml
+
+from .control import MotorController
+from .utils import setup_logger
+
+
+def load_sequence(path: str | Path) -> List[Dict[str, Any]]:
+    """Load a movement sequence from a YAML file."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, list):
+        raise ValueError("Sequence YAML must be a list of steps")
+    return data
+
+
+def play_sequence(controller: MotorController, sequence: List[Dict[str, Any]]) -> None:
+    """Execute a sequence of motor steps."""
+    log = setup_logger("SequencePlayer")
+    for step in sequence:
+        motor = int(step.get("motor", 0))
+        steps = int(step.get("steps", 0))
+        delay = float(step.get("delay", 0))
+        log.info("Motor %d -> %d steps (delay %.2fs)", motor, steps, delay)
+        controller.move_motor(motor, steps)
+        if delay > 0:
+            time.sleep(delay)

--- a/demo_sequence.yaml
+++ b/demo_sequence.yaml
@@ -1,0 +1,13 @@
+# Example motor sequence for Neuropuppet
+- motor: 1
+  steps: 200
+  delay: 0.5
+- motor: 2
+  steps: -200
+  delay: 0.5
+- motor: 3
+  steps: 150
+  delay: 0.5
+- motor: 1
+  steps: -200
+  delay: 0.5

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--config", default="config.yaml", help="Path to config file")
     parser.add_argument("--train", action="store_true", help="Run PPO training")
     parser.add_argument("--timesteps", type=int, help="Override training steps")
+    parser.add_argument("--sequence", help="Run movement sequence from YAML")
     return parser.parse_args()
 
 
@@ -32,6 +33,15 @@ def main() -> None:
         baudrate=int(serial_cfg.get("baudrate", 115200)),
         timeout=float(serial_cfg.get("timeout", 1.0)),
     )
+
+    if args.sequence:
+        from core.sequence import load_sequence, play_sequence
+        sequence = load_sequence(args.sequence)
+        try:
+            play_sequence(controller, sequence)
+        finally:
+            controller.close()
+        return
 
     tracker = PoseTracker(
         camera_index=int(vision_cfg.get("camera_index", 0)),


### PR DESCRIPTION
## Summary
- add ability to run a motor sequence from YAML via `--sequence`
- implement helper module to load and execute sequences
- document scripted sequences and example file

## Testing
- `python -m py_compile main.py core/*.py web/app.py`

------
https://chatgpt.com/codex/tasks/task_e_68508070ddd083248ee26c6fb989c178